### PR TITLE
Fully qualified `cli_executable_version` for all linters

### DIFF
--- a/megalinter/Linter.py
+++ b/megalinter/Linter.py
@@ -22,6 +22,7 @@ import errno
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -691,10 +692,6 @@ class Linter:
     # Returns the version of the associated linter (can be overridden in special cases, like version has special format)
     def get_linter_version_output(self):
         command = self.build_version_command()
-        if sys.platform == "win32":
-            cli_absolute = shutil.which(command[0])
-            if cli_absolute is not None:
-                command[0] = cli_absolute
         logging.debug("Linter version command: " + str(command))
         try:
             process = subprocess.run(
@@ -877,7 +874,10 @@ class Linter:
 
     # Build the CLI command to get linter version (can be overridden if --version is not the way to get the version)
     def build_version_command(self):
-        cmd = [self.cli_executable_version]
+        cmd = shlex.split(self.cli_executable_version)
+        cli_absolute = shutil.which(cmd[0])
+        if cli_absolute is not None:
+            cmd[0] = cli_absolute
         cmd += self.cli_version_extra_args
         if self.cli_version_arg_name != "":
             cmd += [self.cli_version_arg_name]


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #845

**WARNING** there are still others Win32 patch in source code. I recommand to fix it ASAP to allows Windows 64 bit architecture too !

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Remove patch to Windows 32 bit only : https://github.com/nvuillam/mega-linter/blob/v4.46.0/megalinter/Linter.py#L691-L694
2. Since Python 3.3, Windows platform are supported on [shutil.which](https://docs.python.org/3/library/shutil.html#shutil.which) function 


## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
