### PR TITLE
Fix upgrader removing all jobs after cancel_duplicates but last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Note: Can be used with `megalinter/megalinter@beta` in your GitHub Action mega-l
   - [cfn-lint](https://github.com/martysweet/cfn-lint) from 0.54.4 to **0.55.0** on 2021-11-03
   - [phpstan](https://phpstan.org/) from 1.0.0 to **1.0.1** on 2021-11-03
 <!-- linter-versions-end -->
+- Fix that upgrader removed all jobs after cancel_duplicates but the last (#925)  
 
 ## [v5.0.6]
 

--- a/mega-linter-runner/lib/upgrade.js
+++ b/mega-linter-runner/lib/upgrade.js
@@ -161,7 +161,7 @@ class MegaLinterUpgrader {
       // Job "cancel_duplicate"
       {
         regex:
-          /(?<prev_jobs>jobs\s*:(?:.|\n)*)\n(?<indent> *)cancel_duplicates\s*:(?:.|\n)*\n(?<next_job_key>\k<indent>\S*\s*:)/gim,
+          /(?<prev_jobs>jobs\s*:(?:.|\n)*)\n(?<indent> *)cancel_duplicates\s*:(?:.|\n)*?\n(?<next_job_key>\k<indent>\S*\s*:)/gim,
         replacement: `concurrency:
   group: \${{ github.ref }}-\${{ github.workflow }}
   cancel-in-progress: true
@@ -170,6 +170,9 @@ $<prev_jobs>
 $<next_job_key>`,
         test: `
 jobs:
+  preceding_job:
+    # ..
+
   # Cancel duplicate jobs: https://github.com/fkirc/skip-duplicate-actions#option-3-cancellation-only
   cancel_duplicates:
     name: Cancel duplicate jobs
@@ -180,6 +183,9 @@ jobs:
           github_token: \${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           cancel_others: true
 
+  intermediate_job:
+    # ..
+
   build:
     name: Mega-Linter
 `,
@@ -189,7 +195,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  preceding_job:
+    # ..
+
   # Cancel duplicate jobs: https://github.com/fkirc/skip-duplicate-actions#option-3-cancellation-only
+  intermediate_job:
+    # ..
+
   build:
     name: Mega-Linter
 `,


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

The regular expression added in #921 was a little too greedy and removed all jobs in a workflow starting with `cancel_duplicates` but the last.

**Example:**

```yml
jobs:
  preceding_job:
    #..
  # Cancel duplicate jobs: https://github.com/fkirc/skip-duplicate-actions#option-3-cancellation-only
  cancel_duplicates:
    name: Cancel duplicate jobs
    runs-on: ubuntu-latest
    steps:
      - uses: fkirc/skip-duplicate-actions@master
        with:
          github_token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
          cancel_others: true

  intermediate_job:
    #..
  build:
    #..
```

would become

```yml
jobs:
  preceding_job:
    #..
  # Cancel duplicate jobs: https://github.com/fkirc/skip-duplicate-actions#option-3-cancellation-only
  build:
```

**missing the intermediate_job**.


## Proposed Changes

1. Fix regex (see [regex101](https://regex101.com/r/Vand2F/1))
2. Update test case

## Readiness Checklist

### Author/Contributor
- [X] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`

