### PR TITLE
update Mega-Linter docker image to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ You may activate [File.io reporter](https://megalinter.github.io/reporters/FileI
 stage('Mega-Linter') {
     agent {
         docker {
-            image 'megalinter/megalinter:v4'
+            image 'megalinter/megalinter:v5'
             args "-e VALIDATE_ALL_CODEBASE=true -v ${WORKSPACE}:/tmp/lint --entrypoint=''"
             reuseNode true
         }


### PR DESCRIPTION
v4 is deprecated

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
