### PR TITLE
Allow GithubStatusReporter to work for other CI platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Note: Can be used with `megalinter/megalinter@beta` in your GitHub Action mega-l
 - Documentation versioning with mike
 - Accordingly, to official [PHPStan documentation](https://phpstan.org/user-guide/rule-levels), the TEMPLATES/phpstan.neon.dist config file set default level to zero.
 - Downgrade dotnet from 6.0 to 5.0, to be compliant with tsqllint
+- Allow GithubStatusReporter to work for other CI platforms
 
 - Linter versions upgrades
   - [cspell](https://github.com/streetsidesoftware/cspell/tree/master/packages/cspell) from 5.12.5 to **5.12.6** on 2021-11-04

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,7 +37,7 @@ You can also use **beta** version (corresponding to the content of main branch)
 **NOTES:**
 
 - If you pass the _Environment_ variable `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` in your workflow, then the **GitHub MegaLinter** will mark the status of each individual linter run in the Checks section of a pull request. Without this you will only see the overall status of the full run. There is no need to set the **GitHub** Secret as it is automatically set by GitHub, it only needs to be passed to the action.
-- You can also **use it outside of GitHub Actions** (CircleCI, Azure Pipelines, Jenkins, GitLab, or even locally with a docker run)
+- You can also **use it outside of GitHub Actions** (CircleCI, Azure Pipelines, Jenkins, GitLab, or even locally with a docker run) provided that `GITHUB_TARGET_URL` environment variable exists.
 
 In your repository you should have a `.github/workflows` folder with **GitHub** Action similar to below:
 

--- a/megalinter/reporters/GithubStatusReporter.py
+++ b/megalinter/reporters/GithubStatusReporter.py
@@ -33,7 +33,6 @@ class GithubStatusReporter(Reporter):
             config.exists("GITHUB_REPOSITORY")
             and config.exists("GITHUB_SHA")
             and config.exists("GITHUB_TOKEN")
-            and config.exists("GITHUB_RUN_ID")
         ):
             github_repo = config.get("GITHUB_REPOSITORY")
             github_server_url = config.get("GITHUB_SERVER_URL", self.github_server_url)
@@ -49,7 +48,10 @@ class GithubStatusReporter(Reporter):
                 "authorization": f"Bearer {config.get('GITHUB_TOKEN')}",
                 "content-type": "application/json",
             }
-            target_url = f"{github_server_url}/{github_repo}/actions/runs/{run_id}"
+            if config.exists("GITHUB_RUN_ID"):
+                target_url = f"{github_server_url}/{github_repo}/actions/runs/{run_id}"
+            else:
+                target_url = config.get("GITHUB_TARGET_URL")
             description = (
                 success_msg
                 if self.master.status == "success" and self.master.return_code == 0


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes N/A

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

According to the [docs](https://github.com/megalinter/megalinter/blob/main/docs/installation.md#github-action), megalinter should be able to mark the status of each linter in the Checks section of a PR. While this works as stated for GithubCommentReporter, it does not for GithubStatusReporter as it expects a `GITHUB_RUN_ID` in order to activate the reporter. If we are not using GitHub Actions, then this reporter will not work for other CI tools.

1.  Remove mandatory check for `GITHUB_RUN_ID`. This will always exist if it comes from a GitHub Action.
2. If not a GitHub Action, then `target_url` can be retrieved from an env var `GITHUB_TARGET_URL`.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
