### PR TITLE
Psalm linter allows `list_of_files` default mode to scan in one call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Note: Can be used with `megalinter/megalinter@beta` in your GitHub Action mega-l
 - Bypass random CI issue with sql_tsqllint_test test version and test help
 - New configuration **PRINT_ALL_FILES** (default: `true`). If set to `false`, console log only displays updated and error files, not all of them
 - Update **black** configuration, that now uses a `pyproject.toml` file (#949)
+- Allows `list_of_files` cli_lint_mode on Psalm linter to improve performance compare to `file` mode
 
 - Linter versions upgrades
   - [cspell](https://github.com/streetsidesoftware/cspell/tree/master/packages/cspell) from 5.12.5 to **5.12.6** on 2021-11-04

--- a/docs/descriptors/php_psalm.md
+++ b/docs/descriptors/php_psalm.md
@@ -66,7 +66,7 @@ This linter is available in the following flavours
 <!-- /* cSpell:disable */ -->
 ### How the linting is performed
 
-- psalm is called one time by identified file
+- psalm is called once with the list of files as arguments
 
 ### Example calls
 
@@ -75,7 +75,15 @@ psalm myfile.php
 ```
 
 ```shell
+psalm myfile.php mydir/
+```
+
+```shell
 psalm --config=psalm.xml myfile.php
+```
+
+```shell
+psalm --config=psalm.xml myfile.php mydir/
 ```
 
 

--- a/megalinter/descriptors/php.megalinter-descriptor.yml
+++ b/megalinter/descriptors/php.megalinter-descriptor.yml
@@ -127,11 +127,14 @@ linters:
     linter_rules_configuration_url: https://psalm.dev/docs/running_psalm/configuration/
     linter_rules_inline_disable_url: https://psalm.dev/docs/running_psalm/dealing_with_code_issues/#docblock-suppression
     config_file_name: psalm.xml
+    cli_lint_mode: list_of_files
     cli_config_arg_name: "--config="
     version_extract_regex: "((\\d+(\\.\\d+)+)|Psalm (.*)@)"
     examples:
       - "psalm myfile.php"
+      - "psalm myfile.php mydir/"
       - "psalm --config=psalm.xml myfile.php"
+      - "psalm --config=psalm.xml myfile.php mydir/"
     install:
       dockerfile:
         - |

--- a/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json
@@ -6978,7 +6978,7 @@
     },
     "PHP_PSALM_CLI_LINT_MODE": {
       "$id": "#/properties/PHP_PSALM_CLI_LINT_MODE",
-      "default": "file",
+      "default": "list_of_files",
       "enum": [
         "file",
         "list_of_files",


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #964

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. switch default `cli_lint_mode` to `list_of_files` in `megalinter/descriptors/php.megalinter-descriptor.yml`

## Readiness Checklist

### Author/Contributor
- [X] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [X] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
