### PR TITLE
Fix wrong errors count displayed with PHPStan and Psalm linters

### DIFF
--- a/megalinter/descriptors/php.megalinter-descriptor.yml
+++ b/megalinter/descriptors/php.megalinter-descriptor.yml
@@ -101,6 +101,8 @@ linters:
       - "--no-ansi"
       - "--memory-limit"
       - "1G"
+    cli_lint_errors_count: regex_number
+    cli_lint_errors_regex: "Found ([0-9]+) error"
     examples:
       - "phpstan analyse --no-progress --no-ansi myfile.php"
       - "phpstan analyse --no-progress --no-ansi -c phpstan.neon myfile.php"
@@ -130,6 +132,8 @@ linters:
     cli_lint_mode: list_of_files
     cli_config_arg_name: "--config="
     version_extract_regex: "((\\d+(\\.\\d+)+)|Psalm (.*)@)"
+    cli_lint_errors_count: regex_number
+    cli_lint_errors_regex: "([0-9]+) error"
     examples:
       - "psalm myfile.php"
       - "psalm myfile.php mydir/"


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #963 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Keep regexp with "error" rather than "errors" in case we found only one error during analysis

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
