### PR TITLE
markdown-link-check v3.9.0 

### DIFF
--- a/megalinter/descriptors/markdown.megalinter-descriptor.yml
+++ b/megalinter/descriptors/markdown.megalinter-descriptor.yml
@@ -95,7 +95,6 @@ linters:
     config_file_name: .markdown-link-check.json
     cli_lint_errors_count: regex_sum
     cli_lint_errors_regex: "ERROR: ([0-9]+) dead links found"
-    linter_version_cache: "0.0.0" # markdown-link-check does notnumber provide version :/
     examples:
       - "markdown-link-check myfile.md"
       - "markdown-link-check -c .markdown-link-check.json myfile.md"


### PR DESCRIPTION
markdown-link-check [v3.9.0](https://github.com/tcort/markdown-link-check/releases/tag/v3.9.0) is able to display current linter version

In Action 
![md_link_check](https://user-images.githubusercontent.com/364342/143242221-dfaacac4-2ebf-4727-8c20-f11cb2de4260.png)


<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->


<!-- markdownlint-restore -->

<!-- Describe what the changes are -->


## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
