### PR TITLE
Make python linters play nice with each other

### DIFF
--- a/TEMPLATES/.flake8
+++ b/TEMPLATES/.flake8
@@ -1,2 +1,3 @@
 [flake8]
-max-line-length = 120
+max-line-length = 88
+extend-ignore = E203

--- a/TEMPLATES/.python-lint
+++ b/TEMPLATES/.python-lint
@@ -128,7 +128,9 @@ disable=print-statement,
         dict-items-not-iterating,
         dict-keys-not-iterating,
         dict-values-not-iterating,
-        import-error
+        import-error,
+        C0330,
+        C0326
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -410,7 +412,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=88
 
 # Maximum number of lines in a module
 max-module-lines=1000

--- a/TEMPLATES/pyproject.toml
+++ b/TEMPLATES/pyproject.toml
@@ -1,2 +1,2 @@
 [tool.black]
-# line-length = 120
+# line-length = 88


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

I may be missing something, but putting 4+ python linters together seems like a good challenge to make them all play nice. Fortunately, Black as a guide to do so: [https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html](https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html). I chose Black as it's the most popular Python linter currently implemented by stars on Github.

I didn't see these settings set for Pylint and Flake8 but did see the profile set for `isort`. The Pylint config had a lot of stuff in there so may have missed something. I also note the Black suggested rules to disable in Pylint are named differently than the current rules to disable in Pylint, but I tried out Pylint with this config and seems to work.

Also fixed this very minor issue: https://github.com/megalinter/megalinter/pull/951#discussion_r744781586

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Change Pylint and Flake8 defaults to be compatible with Black

## Readiness Checklist

### Author/Contributor
- [ x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
