### PR TITLE
Add yamllint compatibility for prettier

### DIFF
--- a/.automation/test/yaml/yml_good_1.yml
+++ b/.automation/test/yaml/yml_good_1.yml
@@ -13,6 +13,6 @@ env:
   es6: true
   jest: true
 
-Here: there
+Here: there # good comment
 
 something: "For Nothing"

--- a/TEMPLATES/.yamllint.yml
+++ b/TEMPLATES/.yamllint.yml
@@ -13,3 +13,5 @@ rules:
     type: unix
   line-length:
     max: 500
+  comments:
+    min-spaces-from-content: 1 # Used to follow prettier standard: https://github.com/prettier/prettier/pull/10926


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes incompatibility between prettier and yamllint for yaml files. Prettier has a standard for 1 space between content and comment in yaml, and it fixes files to this standard. They do not plan on changing it or enabling the user to change it: https://github.com/prettier/prettier/pull/10926

yamllint enables configuation, so let's just go with the prettier (and more popular/relaxed) standard.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

Also added in a test case that shouldn't fail on a singly spaced comment.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
