### PR TITLE
Avoid storing copies of files in layer for kubeval, shellcheck, and misspell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -318,8 +318,11 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 
 
 # shellcheck installation
-RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
-    && cp "shellcheck-stable/shellcheck" /usr/bin/ \
+RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv --directory ${ML_THIRD_PARTY_DIR} \
+    && mv "${ML_THIRD_PARTY_DIR}/shellcheck-stable/shellcheck" /usr/bin/ \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
     && shellcheck --version
 
 
@@ -372,10 +375,12 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
 
 
 # kubeval installation
-RUN wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-    && tar xf kubeval-linux-amd64.tar.gz \
-    && cp kubeval /usr/local/bin
-
+RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -P ${ML_THIRD_PARTY_DIR} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+    && tar xf ${ML_THIRD_PARTY_DIR}/kubeval-linux-amd64.tar.gz --directory ${ML_THIRD_PARTY_DIR} \
+    && mv ${ML_THIRD_PARTY_DIR}/kubeval /usr/local/bin \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete
 
 # chktex installation
 COPY --from=chktex /usr/bin/chktex /usr/bin/
@@ -453,8 +458,12 @@ RUN sfdx plugins:install @salesforce/sfdx-scanner
 RUN ./coursier install scalafix --quiet --install-dir /usr/bin
 
 # misspell installation
-RUN curl -L -o ./install-misspell.sh https://git.io/misspell \
-    && sh ./install-misspell.sh
+RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && curl -L -o ${ML_THIRD_PARTY_DIR}/install-misspell.sh https://git.io/misspell \
+    && sh .${ML_THIRD_PARTY_DIR}/install-misspell.sh \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+    && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
 
 
 # tsqllint installation

--- a/flavors/dart/Dockerfile
+++ b/flavors/dart/Dockerfile
@@ -166,8 +166,11 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 
 
 # shellcheck installation
-RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
-    && cp "shellcheck-stable/shellcheck" /usr/bin/ \
+RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv --directory ${ML_THIRD_PARTY_DIR} \
+    && mv "${ML_THIRD_PARTY_DIR}/shellcheck-stable/shellcheck" /usr/bin/ \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
     && shellcheck --version
 
 
@@ -197,17 +200,23 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
 
 
 # kubeval installation
-RUN wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-    && tar xf kubeval-linux-amd64.tar.gz \
-    && cp kubeval /usr/local/bin
-
+RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -P ${ML_THIRD_PARTY_DIR} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+    && tar xf ${ML_THIRD_PARTY_DIR}/kubeval-linux-amd64.tar.gz --directory ${ML_THIRD_PARTY_DIR} \
+    && mv ${ML_THIRD_PARTY_DIR}/kubeval /usr/local/bin \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete
 
 # protolint installation
 COPY --from=protolint /usr/local/bin/protolint /usr/bin/
 
 # misspell installation
-RUN curl -L -o ./install-misspell.sh https://git.io/misspell \
-    && sh ./install-misspell.sh
+RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && curl -L -o ${ML_THIRD_PARTY_DIR}/install-misspell.sh https://git.io/misspell \
+    && sh .${ML_THIRD_PARTY_DIR}/install-misspell.sh \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+    && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
 
 
 #OTHER__END

--- a/flavors/documentation/Dockerfile
+++ b/flavors/documentation/Dockerfile
@@ -165,8 +165,11 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 
 
 # shellcheck installation
-RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
-    && cp "shellcheck-stable/shellcheck" /usr/bin/ \
+RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv --directory ${ML_THIRD_PARTY_DIR} \
+    && mv "${ML_THIRD_PARTY_DIR}/shellcheck-stable/shellcheck" /usr/bin/ \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
     && shellcheck --version
 
 
@@ -186,17 +189,23 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
 
 
 # kubeval installation
-RUN wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-    && tar xf kubeval-linux-amd64.tar.gz \
-    && cp kubeval /usr/local/bin
-
+RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -P ${ML_THIRD_PARTY_DIR} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+    && tar xf ${ML_THIRD_PARTY_DIR}/kubeval-linux-amd64.tar.gz --directory ${ML_THIRD_PARTY_DIR} \
+    && mv ${ML_THIRD_PARTY_DIR}/kubeval /usr/local/bin \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete
 
 # protolint installation
 COPY --from=protolint /usr/local/bin/protolint /usr/bin/
 
 # misspell installation
-RUN curl -L -o ./install-misspell.sh https://git.io/misspell \
-    && sh ./install-misspell.sh
+RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && curl -L -o ${ML_THIRD_PARTY_DIR}/install-misspell.sh https://git.io/misspell \
+    && sh .${ML_THIRD_PARTY_DIR}/install-misspell.sh \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+    && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
 
 
 #OTHER__END

--- a/flavors/dotnet/Dockerfile
+++ b/flavors/dotnet/Dockerfile
@@ -201,8 +201,11 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 
 
 # shellcheck installation
-RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
-    && cp "shellcheck-stable/shellcheck" /usr/bin/ \
+RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv --directory ${ML_THIRD_PARTY_DIR} \
+    && mv "${ML_THIRD_PARTY_DIR}/shellcheck-stable/shellcheck" /usr/bin/ \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
     && shellcheck --version
 
 
@@ -225,10 +228,12 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
 
 
 # kubeval installation
-RUN wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-    && tar xf kubeval-linux-amd64.tar.gz \
-    && cp kubeval /usr/local/bin
-
+RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -P ${ML_THIRD_PARTY_DIR} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+    && tar xf ${ML_THIRD_PARTY_DIR}/kubeval-linux-amd64.tar.gz --directory ${ML_THIRD_PARTY_DIR} \
+    && mv ${ML_THIRD_PARTY_DIR}/kubeval /usr/local/bin \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete
 
 # powershell installation
 RUN pwsh -c 'Install-Module -Name PSScriptAnalyzer -RequiredVersion ${PSSA_VERSION} -Scope AllUsers -Force'
@@ -237,8 +242,12 @@ RUN pwsh -c 'Install-Module -Name PSScriptAnalyzer -RequiredVersion ${PSSA_VERSI
 COPY --from=protolint /usr/local/bin/protolint /usr/bin/
 
 # misspell installation
-RUN curl -L -o ./install-misspell.sh https://git.io/misspell \
-    && sh ./install-misspell.sh
+RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && curl -L -o ${ML_THIRD_PARTY_DIR}/install-misspell.sh https://git.io/misspell \
+    && sh .${ML_THIRD_PARTY_DIR}/install-misspell.sh \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+    && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
 
 
 # tsqllint installation

--- a/flavors/go/Dockerfile
+++ b/flavors/go/Dockerfile
@@ -166,8 +166,11 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 
 
 # shellcheck installation
-RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
-    && cp "shellcheck-stable/shellcheck" /usr/bin/ \
+RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv --directory ${ML_THIRD_PARTY_DIR} \
+    && mv "${ML_THIRD_PARTY_DIR}/shellcheck-stable/shellcheck" /usr/bin/ \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
     && shellcheck --version
 
 
@@ -195,17 +198,23 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
 
 
 # kubeval installation
-RUN wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-    && tar xf kubeval-linux-amd64.tar.gz \
-    && cp kubeval /usr/local/bin
-
+RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -P ${ML_THIRD_PARTY_DIR} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+    && tar xf ${ML_THIRD_PARTY_DIR}/kubeval-linux-amd64.tar.gz --directory ${ML_THIRD_PARTY_DIR} \
+    && mv ${ML_THIRD_PARTY_DIR}/kubeval /usr/local/bin \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete
 
 # protolint installation
 COPY --from=protolint /usr/local/bin/protolint /usr/bin/
 
 # misspell installation
-RUN curl -L -o ./install-misspell.sh https://git.io/misspell \
-    && sh ./install-misspell.sh
+RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && curl -L -o ${ML_THIRD_PARTY_DIR}/install-misspell.sh https://git.io/misspell \
+    && sh .${ML_THIRD_PARTY_DIR}/install-misspell.sh \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+    && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
 
 
 #OTHER__END

--- a/flavors/java/Dockerfile
+++ b/flavors/java/Dockerfile
@@ -171,8 +171,11 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 
 
 # shellcheck installation
-RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
-    && cp "shellcheck-stable/shellcheck" /usr/bin/ \
+RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv --directory ${ML_THIRD_PARTY_DIR} \
+    && mv "${ML_THIRD_PARTY_DIR}/shellcheck-stable/shellcheck" /usr/bin/ \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
     && shellcheck --version
 
 
@@ -204,17 +207,23 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
 
 
 # kubeval installation
-RUN wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-    && tar xf kubeval-linux-amd64.tar.gz \
-    && cp kubeval /usr/local/bin
-
+RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -P ${ML_THIRD_PARTY_DIR} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+    && tar xf ${ML_THIRD_PARTY_DIR}/kubeval-linux-amd64.tar.gz --directory ${ML_THIRD_PARTY_DIR} \
+    && mv ${ML_THIRD_PARTY_DIR}/kubeval /usr/local/bin \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete
 
 # protolint installation
 COPY --from=protolint /usr/local/bin/protolint /usr/bin/
 
 # misspell installation
-RUN curl -L -o ./install-misspell.sh https://git.io/misspell \
-    && sh ./install-misspell.sh
+RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && curl -L -o ${ML_THIRD_PARTY_DIR}/install-misspell.sh https://git.io/misspell \
+    && sh .${ML_THIRD_PARTY_DIR}/install-misspell.sh \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+    && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
 
 
 #OTHER__END

--- a/flavors/javascript/Dockerfile
+++ b/flavors/javascript/Dockerfile
@@ -185,8 +185,11 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 
 
 # shellcheck installation
-RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
-    && cp "shellcheck-stable/shellcheck" /usr/bin/ \
+RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv --directory ${ML_THIRD_PARTY_DIR} \
+    && mv "${ML_THIRD_PARTY_DIR}/shellcheck-stable/shellcheck" /usr/bin/ \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
     && shellcheck --version
 
 
@@ -206,17 +209,23 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
 
 
 # kubeval installation
-RUN wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-    && tar xf kubeval-linux-amd64.tar.gz \
-    && cp kubeval /usr/local/bin
-
+RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -P ${ML_THIRD_PARTY_DIR} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+    && tar xf ${ML_THIRD_PARTY_DIR}/kubeval-linux-amd64.tar.gz --directory ${ML_THIRD_PARTY_DIR} \
+    && mv ${ML_THIRD_PARTY_DIR}/kubeval /usr/local/bin \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete
 
 # protolint installation
 COPY --from=protolint /usr/local/bin/protolint /usr/bin/
 
 # misspell installation
-RUN curl -L -o ./install-misspell.sh https://git.io/misspell \
-    && sh ./install-misspell.sh
+RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && curl -L -o ${ML_THIRD_PARTY_DIR}/install-misspell.sh https://git.io/misspell \
+    && sh .${ML_THIRD_PARTY_DIR}/install-misspell.sh \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+    && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
 
 
 #OTHER__END

--- a/flavors/php/Dockerfile
+++ b/flavors/php/Dockerfile
@@ -202,8 +202,11 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 
 
 # shellcheck installation
-RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
-    && cp "shellcheck-stable/shellcheck" /usr/bin/ \
+RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv --directory ${ML_THIRD_PARTY_DIR} \
+    && mv "${ML_THIRD_PARTY_DIR}/shellcheck-stable/shellcheck" /usr/bin/ \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
     && shellcheck --version
 
 
@@ -223,10 +226,12 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
 
 
 # kubeval installation
-RUN wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-    && tar xf kubeval-linux-amd64.tar.gz \
-    && cp kubeval /usr/local/bin
-
+RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -P ${ML_THIRD_PARTY_DIR} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+    && tar xf ${ML_THIRD_PARTY_DIR}/kubeval-linux-amd64.tar.gz --directory ${ML_THIRD_PARTY_DIR} \
+    && mv ${ML_THIRD_PARTY_DIR}/kubeval /usr/local/bin \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete
 
 # phpcs installation
 RUN phive --no-progress install phpcs -g --trust-gpg-keys 31C7E470E2138192
@@ -250,8 +255,12 @@ ENV PATH="/root/.composer/vendor/bin:$PATH"
 COPY --from=protolint /usr/local/bin/protolint /usr/bin/
 
 # misspell installation
-RUN curl -L -o ./install-misspell.sh https://git.io/misspell \
-    && sh ./install-misspell.sh
+RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && curl -L -o ${ML_THIRD_PARTY_DIR}/install-misspell.sh https://git.io/misspell \
+    && sh .${ML_THIRD_PARTY_DIR}/install-misspell.sh \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+    && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
 
 
 #OTHER__END

--- a/flavors/python/Dockerfile
+++ b/flavors/python/Dockerfile
@@ -175,8 +175,11 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 
 
 # shellcheck installation
-RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
-    && cp "shellcheck-stable/shellcheck" /usr/bin/ \
+RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv --directory ${ML_THIRD_PARTY_DIR} \
+    && mv "${ML_THIRD_PARTY_DIR}/shellcheck-stable/shellcheck" /usr/bin/ \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
     && shellcheck --version
 
 
@@ -196,17 +199,23 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
 
 
 # kubeval installation
-RUN wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-    && tar xf kubeval-linux-amd64.tar.gz \
-    && cp kubeval /usr/local/bin
-
+RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -P ${ML_THIRD_PARTY_DIR} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+    && tar xf ${ML_THIRD_PARTY_DIR}/kubeval-linux-amd64.tar.gz --directory ${ML_THIRD_PARTY_DIR} \
+    && mv ${ML_THIRD_PARTY_DIR}/kubeval /usr/local/bin \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete
 
 # protolint installation
 COPY --from=protolint /usr/local/bin/protolint /usr/bin/
 
 # misspell installation
-RUN curl -L -o ./install-misspell.sh https://git.io/misspell \
-    && sh ./install-misspell.sh
+RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && curl -L -o ${ML_THIRD_PARTY_DIR}/install-misspell.sh https://git.io/misspell \
+    && sh .${ML_THIRD_PARTY_DIR}/install-misspell.sh \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+    && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
 
 
 #OTHER__END

--- a/flavors/ruby/Dockerfile
+++ b/flavors/ruby/Dockerfile
@@ -174,8 +174,11 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 
 
 # shellcheck installation
-RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
-    && cp "shellcheck-stable/shellcheck" /usr/bin/ \
+RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv --directory ${ML_THIRD_PARTY_DIR} \
+    && mv "${ML_THIRD_PARTY_DIR}/shellcheck-stable/shellcheck" /usr/bin/ \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
     && shellcheck --version
 
 
@@ -195,17 +198,23 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
 
 
 # kubeval installation
-RUN wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-    && tar xf kubeval-linux-amd64.tar.gz \
-    && cp kubeval /usr/local/bin
-
+RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -P ${ML_THIRD_PARTY_DIR} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+    && tar xf ${ML_THIRD_PARTY_DIR}/kubeval-linux-amd64.tar.gz --directory ${ML_THIRD_PARTY_DIR} \
+    && mv ${ML_THIRD_PARTY_DIR}/kubeval /usr/local/bin \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete
 
 # protolint installation
 COPY --from=protolint /usr/local/bin/protolint /usr/bin/
 
 # misspell installation
-RUN curl -L -o ./install-misspell.sh https://git.io/misspell \
-    && sh ./install-misspell.sh
+RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && curl -L -o ${ML_THIRD_PARTY_DIR}/install-misspell.sh https://git.io/misspell \
+    && sh .${ML_THIRD_PARTY_DIR}/install-misspell.sh \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+    && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
 
 
 #OTHER__END

--- a/flavors/rust/Dockerfile
+++ b/flavors/rust/Dockerfile
@@ -169,8 +169,11 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 
 
 # shellcheck installation
-RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
-    && cp "shellcheck-stable/shellcheck" /usr/bin/ \
+RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv --directory ${ML_THIRD_PARTY_DIR} \
+    && mv "${ML_THIRD_PARTY_DIR}/shellcheck-stable/shellcheck" /usr/bin/ \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
     && shellcheck --version
 
 
@@ -190,10 +193,12 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
 
 
 # kubeval installation
-RUN wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-    && tar xf kubeval-linux-amd64.tar.gz \
-    && cp kubeval /usr/local/bin
-
+RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -P ${ML_THIRD_PARTY_DIR} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+    && tar xf ${ML_THIRD_PARTY_DIR}/kubeval-linux-amd64.tar.gz --directory ${ML_THIRD_PARTY_DIR} \
+    && mv ${ML_THIRD_PARTY_DIR}/kubeval /usr/local/bin \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete
 
 # protolint installation
 COPY --from=protolint /usr/local/bin/protolint /usr/bin/
@@ -202,8 +207,12 @@ COPY --from=protolint /usr/local/bin/protolint /usr/bin/
 RUN rustup component add clippy
 
 # misspell installation
-RUN curl -L -o ./install-misspell.sh https://git.io/misspell \
-    && sh ./install-misspell.sh
+RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && curl -L -o ${ML_THIRD_PARTY_DIR}/install-misspell.sh https://git.io/misspell \
+    && sh .${ML_THIRD_PARTY_DIR}/install-misspell.sh \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+    && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
 
 
 #OTHER__END

--- a/flavors/salesforce/Dockerfile
+++ b/flavors/salesforce/Dockerfile
@@ -172,8 +172,11 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 
 
 # shellcheck installation
-RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
-    && cp "shellcheck-stable/shellcheck" /usr/bin/ \
+RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv --directory ${ML_THIRD_PARTY_DIR} \
+    && mv "${ML_THIRD_PARTY_DIR}/shellcheck-stable/shellcheck" /usr/bin/ \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
     && shellcheck --version
 
 
@@ -193,10 +196,12 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
 
 
 # kubeval installation
-RUN wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-    && tar xf kubeval-linux-amd64.tar.gz \
-    && cp kubeval /usr/local/bin
-
+RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -P ${ML_THIRD_PARTY_DIR} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+    && tar xf ${ML_THIRD_PARTY_DIR}/kubeval-linux-amd64.tar.gz --directory ${ML_THIRD_PARTY_DIR} \
+    && mv ${ML_THIRD_PARTY_DIR}/kubeval /usr/local/bin \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete
 
 # protolint installation
 COPY --from=protolint /usr/local/bin/protolint /usr/bin/
@@ -211,8 +216,12 @@ RUN sfdx plugins:install @salesforce/sfdx-scanner
 RUN sfdx plugins:install @salesforce/sfdx-scanner
 
 # misspell installation
-RUN curl -L -o ./install-misspell.sh https://git.io/misspell \
-    && sh ./install-misspell.sh
+RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && curl -L -o ${ML_THIRD_PARTY_DIR}/install-misspell.sh https://git.io/misspell \
+    && sh .${ML_THIRD_PARTY_DIR}/install-misspell.sh \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+    && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
 
 
 #OTHER__END

--- a/flavors/scala/Dockerfile
+++ b/flavors/scala/Dockerfile
@@ -170,8 +170,11 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 
 
 # shellcheck installation
-RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
-    && cp "shellcheck-stable/shellcheck" /usr/bin/ \
+RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv --directory ${ML_THIRD_PARTY_DIR} \
+    && mv "${ML_THIRD_PARTY_DIR}/shellcheck-stable/shellcheck" /usr/bin/ \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
     && shellcheck --version
 
 
@@ -191,10 +194,12 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
 
 
 # kubeval installation
-RUN wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-    && tar xf kubeval-linux-amd64.tar.gz \
-    && cp kubeval /usr/local/bin
-
+RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -P ${ML_THIRD_PARTY_DIR} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+    && tar xf ${ML_THIRD_PARTY_DIR}/kubeval-linux-amd64.tar.gz --directory ${ML_THIRD_PARTY_DIR} \
+    && mv ${ML_THIRD_PARTY_DIR}/kubeval /usr/local/bin \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete
 
 # protolint installation
 COPY --from=protolint /usr/local/bin/protolint /usr/bin/
@@ -203,8 +208,12 @@ COPY --from=protolint /usr/local/bin/protolint /usr/bin/
 RUN ./coursier install scalafix --quiet --install-dir /usr/bin
 
 # misspell installation
-RUN curl -L -o ./install-misspell.sh https://git.io/misspell \
-    && sh ./install-misspell.sh
+RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && curl -L -o ${ML_THIRD_PARTY_DIR}/install-misspell.sh https://git.io/misspell \
+    && sh .${ML_THIRD_PARTY_DIR}/install-misspell.sh \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+    && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
 
 
 #OTHER__END

--- a/flavors/swift/Dockerfile
+++ b/flavors/swift/Dockerfile
@@ -168,8 +168,11 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 
 
 # shellcheck installation
-RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
-    && cp "shellcheck-stable/shellcheck" /usr/bin/ \
+RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv --directory ${ML_THIRD_PARTY_DIR} \
+    && mv "${ML_THIRD_PARTY_DIR}/shellcheck-stable/shellcheck" /usr/bin/ \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
     && shellcheck --version
 
 
@@ -189,17 +192,23 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
 
 
 # kubeval installation
-RUN wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-    && tar xf kubeval-linux-amd64.tar.gz \
-    && cp kubeval /usr/local/bin
-
+RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -P ${ML_THIRD_PARTY_DIR} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+    && tar xf ${ML_THIRD_PARTY_DIR}/kubeval-linux-amd64.tar.gz --directory ${ML_THIRD_PARTY_DIR} \
+    && mv ${ML_THIRD_PARTY_DIR}/kubeval /usr/local/bin \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete
 
 # protolint installation
 COPY --from=protolint /usr/local/bin/protolint /usr/bin/
 
 # misspell installation
-RUN curl -L -o ./install-misspell.sh https://git.io/misspell \
-    && sh ./install-misspell.sh
+RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && curl -L -o ${ML_THIRD_PARTY_DIR}/install-misspell.sh https://git.io/misspell \
+    && sh .${ML_THIRD_PARTY_DIR}/install-misspell.sh \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+    && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
 
 
 #OTHER__END

--- a/flavors/terraform/Dockerfile
+++ b/flavors/terraform/Dockerfile
@@ -169,8 +169,11 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 
 
 # shellcheck installation
-RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
-    && cp "shellcheck-stable/shellcheck" /usr/bin/ \
+RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv --directory ${ML_THIRD_PARTY_DIR} \
+    && mv "${ML_THIRD_PARTY_DIR}/shellcheck-stable/shellcheck" /usr/bin/ \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
     && shellcheck --version
 
 
@@ -190,17 +193,23 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
 
 
 # kubeval installation
-RUN wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-    && tar xf kubeval-linux-amd64.tar.gz \
-    && cp kubeval /usr/local/bin
-
+RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && wget -P ${ML_THIRD_PARTY_DIR} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+    && tar xf ${ML_THIRD_PARTY_DIR}/kubeval-linux-amd64.tar.gz --directory ${ML_THIRD_PARTY_DIR} \
+    && mv ${ML_THIRD_PARTY_DIR}/kubeval /usr/local/bin \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete
 
 # protolint installation
 COPY --from=protolint /usr/local/bin/protolint /usr/bin/
 
 # misspell installation
-RUN curl -L -o ./install-misspell.sh https://git.io/misspell \
-    && sh ./install-misspell.sh
+RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
+    && mkdir -p ${ML_THIRD_PARTY_DIR} \
+    && curl -L -o ${ML_THIRD_PARTY_DIR}/install-misspell.sh https://git.io/misspell \
+    && sh .${ML_THIRD_PARTY_DIR}/install-misspell.sh \
+    && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+    && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
 
 
 # tflint installation

--- a/megalinter/descriptors/bash.megalinter-descriptor.yml
+++ b/megalinter/descriptors/bash.megalinter-descriptor.yml
@@ -52,8 +52,10 @@ linters:
     install:
       dockerfile:
         - |
-          RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
-              && cp "shellcheck-stable/shellcheck" /usr/bin/ \
+          RUN MLDL=/downloads/shellcheck && mkdir -p ${MLDL} \
+              && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv -C ${MLDL} \
+              && mv "${MLDL}/shellcheck-stable/shellcheck" /usr/bin/ \
+              && find ${MLDL} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
               && shellcheck --version
     ide:
       atom:

--- a/megalinter/descriptors/bash.megalinter-descriptor.yml
+++ b/megalinter/descriptors/bash.megalinter-descriptor.yml
@@ -52,10 +52,11 @@ linters:
     install:
       dockerfile:
         - |
-          RUN MLDL=/downloads/shellcheck && mkdir -p ${MLDL} \
-              && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv -C ${MLDL} \
-              && mv "${MLDL}/shellcheck-stable/shellcheck" /usr/bin/ \
-              && find ${MLDL} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+          RUN ML_THIRD_PARTY_DIR="/third-party/shellcheck" \
+              && mkdir -p ${ML_THIRD_PARTY_DIR} \
+              && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv --directory ${ML_THIRD_PARTY_DIR} \
+              && mv "${ML_THIRD_PARTY_DIR}/shellcheck-stable/shellcheck" /usr/bin/ \
+              && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
               && shellcheck --version
     ide:
       atom:

--- a/megalinter/descriptors/kubernetes.megalinter-descriptor.yml
+++ b/megalinter/descriptors/kubernetes.megalinter-descriptor.yml
@@ -25,6 +25,8 @@ linters:
     install:
       dockerfile:
         - |
-          RUN wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-              && tar xf kubeval-linux-amd64.tar.gz \
-              && cp kubeval /usr/local/bin
+          RUN MLDL=/downloads/kubeval && mkdir -p ${MLDL} \
+              && wget -P ${MLDL} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+              && tar xf ${MLDL}/kubeval-linux-amd64.tar.gz -C /downloads/kubeval \
+              && mv ${MLDL}/kubeval /usr/local/bin \
+              && find ${MLDL} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete

--- a/megalinter/descriptors/kubernetes.megalinter-descriptor.yml
+++ b/megalinter/descriptors/kubernetes.megalinter-descriptor.yml
@@ -25,8 +25,9 @@ linters:
     install:
       dockerfile:
         - |
-          RUN MLDL=/downloads/kubeval && mkdir -p ${MLDL} \
-              && wget -P ${MLDL} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
-              && tar xf ${MLDL}/kubeval-linux-amd64.tar.gz -C /downloads/kubeval \
-              && mv ${MLDL}/kubeval /usr/local/bin \
-              && find ${MLDL} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete
+          RUN ML_THIRD_PARTY_DIR="/third-party/kubeval" \
+              && mkdir -p ${ML_THIRD_PARTY_DIR} \
+              && wget -P ${ML_THIRD_PARTY_DIR} -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz \
+              && tar xf ${ML_THIRD_PARTY_DIR}/kubeval-linux-amd64.tar.gz --directory ${ML_THIRD_PARTY_DIR} \
+              && mv ${ML_THIRD_PARTY_DIR}/kubeval /usr/local/bin \
+              && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete

--- a/megalinter/descriptors/spell.megalinter-descriptor.yml
+++ b/megalinter/descriptors/spell.megalinter-descriptor.yml
@@ -23,8 +23,11 @@ linters:
     install:
       dockerfile:
         - |
-          RUN curl -L -o ./install-misspell.sh https://git.io/misspell \
-              && sh ./install-misspell.sh
+          RUN MLDL=/downloads/misspell && mkdir -p ${MLDL} \
+              && curl -L -o ${MLDL}/install-misspell.sh https://git.io/misspell \
+              && sh .${MLDL}/install-misspell.sh \
+              && find ${MLDL} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+              && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
   # CSPELL
   - class: CSpellLinter
     linter_name: cspell

--- a/megalinter/descriptors/spell.megalinter-descriptor.yml
+++ b/megalinter/descriptors/spell.megalinter-descriptor.yml
@@ -23,10 +23,11 @@ linters:
     install:
       dockerfile:
         - |
-          RUN MLDL=/downloads/misspell && mkdir -p ${MLDL} \
-              && curl -L -o ${MLDL}/install-misspell.sh https://git.io/misspell \
-              && sh .${MLDL}/install-misspell.sh \
-              && find ${MLDL} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
+          RUN ML_THIRD_PARTY_DIR="/third-party/misspell" \
+              && mkdir -p ${ML_THIRD_PARTY_DIR} \
+              && curl -L -o ${ML_THIRD_PARTY_DIR}/install-misspell.sh https://git.io/misspell \
+              && sh .${ML_THIRD_PARTY_DIR}/install-misspell.sh \
+              && find ${ML_THIRD_PARTY_DIR} -type f -not -name 'LICENSE*' -delete -o -type d -empty -delete \
               && find /tmp -path '/tmp/tmp.*' -type f -name 'misspell*' -delete -o -type d -empty -delete
   # CSPELL
   - class: CSpellLinter


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

 I logged into an interactive shell of the container to be able to see where the disk space was taken.
```console
$ docker run -it --entrypoint /bin/bash megalinter/megalinter:v5
```
We can see that at the root, there are extra files
```console
$ ls -lah --color=always
total 11M
drwxr-xr-x    1 root root    4.0K Jan 31 08:50 .
drwxr-xr-x    1 root root    4.0K Jan 31 08:50 ..
-rwxr-xr-x    1 root root       0 Jan 31 08:50 .dockerenv
-rw-r--r--    1 root root      19 Jan 30 16:35 .npmrc
-rw-r--r--    1  503 dialout  646 Oct  5  2020 LICENSE
-rw-r--r--    1  503 dialout  917 Oct  5  2020 README.md
drwxr-xr-x    3 root root    4.0K Jan 30 17:04 action
drwxr-xr-x    1 root root    4.0K Jan 30 16:58 bin
-rwxr-xr-x    1 root root     42K Jan 30 16:46 coursier
drwxr-xr-x    5 root root     360 Jan 31 08:50 dev
drwxr-xr-x    2 root root    4.0K Jan 30 17:03 dist
-rwxr-xr-x    1 root root     55K Jan 30 16:39 dotnet-install.sh
-rwxr-xr-x    1 root root    1.3K Jan 30 16:31 entrypoint.sh
drwxr-xr-x    1 root root    4.0K Jan 31 08:50 etc
drwxr-xr-x    4 root root    4.0K Jan 30 16:38 false
drwxr-xr-x    1 root root    4.0K Jan 30 16:46 go
drwxr-xr-x    1 root root    4.0K Jan 30 16:53 home
-rw-r--r--    1 root root    8.7K Jan 30 16:58 install-misspell.sh
-rwxr-xr-x    1  503 dialout 7.1M Mar 30  2021 kubeval
-rw-r--r--    1 root root    2.8M Jan 30 16:49 kubeval-linux-amd64.tar.gz
drwxr-xr-x    1 root root    4.0K Jan 30 16:48 lib
drwxr-xr-x    2 root root    4.0K Jan 30 16:48 lib64
drwxr-xr-x    5 root root    4.0K Aug 31 13:34 media
drwxr-xr-x    6 root root    4.0K Jan 30 17:03 megalinter
drwxr-xr-x    3 root root    4.0K Jan 30 17:03 megalinter-descriptors
drwxr-xr-x    2 root root    4.0K Jan 30 17:03 megalinter.egg-info
drwxr-xr-x    2 root root    4.0K Aug 31 13:34 mnt
drwxr-xr-x 1104 root root     36K Jan 30 16:38 node_modules
drwxr-xr-x    1 root root    4.0K Jan 30 17:01 opt
dr-xr-xr-x  308 root root       0 Jan 31 08:50 proc
drwx------    1 root root    4.0K Jan 30 16:59 root
drwxr-xr-x    2 root root    4.0K Aug 31 13:34 run
drwxr-xr-x    1 root root    4.0K Jan 30 16:33 sbin
drwxr-xr-x    2 root root    4.0K Jan 30 16:47 shellcheck-stable
drwxr-xr-x    2 root root    4.0K Aug 31 13:34 srv
dr-xr-xr-x   11 root root       0 Jan 31 08:50 sys
drwxrwxrwt    1 root root    4.0K Jan 30 16:59 tmp
drwxr-xr-x    1 root root    4.0K Jan 30 16:48 usr
drwxr-xr-x    1 root root    4.0K Jan 30 16:33 var
```

I made my PR by testing with the terraform flavor, since it was smaller than all, and contained the kubeval tool.
But I continued to explore what else could take space. 

To drill down where the space is taken, we can use `ncdu`
```console
$ apk add ncdu
$ ncdu -e --color dark -2 -r
```

<details>
  <summary>Expand screenshots of disk usage</summary>

 ![image](https://user-images.githubusercontent.com/27212526/151764822-c4c7f7c9-6d8b-4c01-b50d-88e7ddac5f66.png)
![image](https://user-images.githubusercontent.com/27212526/151765203-f41b439f-b7b9-498c-972a-d3d5cab22b9b.png)
![image](https://user-images.githubusercontent.com/27212526/151765361-cc2edbd6-9125-4ae4-af62-e6a444086ce3.png)
![image](https://user-images.githubusercontent.com/27212526/151765387-9a3d7d1e-32ef-4dc7-a4f2-8b75fdc697d1.png)
![image](https://user-images.githubusercontent.com/27212526/151765435-44bb71a2-b112-4f62-b1c8-3e81c81f472a.png)
![image](https://user-images.githubusercontent.com/27212526/151765486-4c0ef191-89f9-47b9-a8d4-13aa5bbf46a3.png)
![image](https://user-images.githubusercontent.com/27212526/151765580-1e0293a4-304c-434c-b156-4446d289a83f.png)
![image](https://user-images.githubusercontent.com/27212526/151765600-64401ec8-71e3-411c-b55a-867f57e09500.png)
![image](https://user-images.githubusercontent.com/27212526/151765631-32dd3795-f03c-4e81-b60f-2a08e030e870.png)
![image](https://user-images.githubusercontent.com/27212526/151765655-e48ee784-c4a2-4389-aabf-82362882a842.png)
![image](https://user-images.githubusercontent.com/27212526/151766071-f6467a38-863d-41ae-adac-9607397077eb.png)![image](https://user-images.githubusercontent.com/27212526/151765771-015dcead-ef78-4d3c-bc1f-e735e3c5fadb.png)
![image](https://user-images.githubusercontent.com/27212526/151765812-f8be7b25-a6f9-45ce-9eb4-a93351d76159.png)
![image](https://user-images.githubusercontent.com/27212526/151765832-f6b0948f-a650-4799-94f2-aaf895b4d551.png)
![image](https://user-images.githubusercontent.com/27212526/151765857-420a7280-bed5-4183-95ed-55d63f60f2c0.png)
![image](https://user-images.githubusercontent.com/27212526/151766145-7f9a0ac5-3b33-43fb-84d9-983bf75d877b.png)

-----
![image](https://user-images.githubusercontent.com/27212526/151766206-f8b99df6-2c47-42ef-b432-404ba87446eb.png)
![image](https://user-images.githubusercontent.com/27212526/151766232-77e14414-4fcd-49bf-a0c7-e9bcea5690f0.png)
![image](https://user-images.githubusercontent.com/27212526/151766257-d07a08d2-b1e7-479a-8d88-f6f11161b63d.png)
![image](https://user-images.githubusercontent.com/27212526/151766332-bae44f86-aa3c-43e8-9f49-b702bb17b651.png)
![image](https://user-images.githubusercontent.com/27212526/151766486-d3d7dee6-9849-4cf6-9c40-b62da1194e10.png)
![image](https://user-images.githubusercontent.com/27212526/151766522-c40676ad-da38-4772-b9ed-8fca1bedee8c.png)

-----

![image](https://user-images.githubusercontent.com/27212526/151766633-7c6e0cc0-e6e4-4eb2-a8c9-ed9339f1d144.png)
![image](https://user-images.githubusercontent.com/27212526/151766669-b6887234-2c58-4eae-891f-12ba887e72c2.png)
![image](https://user-images.githubusercontent.com/27212526/151766694-4d6c6dd6-2c24-4ee2-b091-d10e2b91fc6d.png)
![image](https://user-images.githubusercontent.com/27212526/151766737-fff055ff-61b8-4ca0-80d9-744b5572e082.png)
![image](https://user-images.githubusercontent.com/27212526/151766759-5f7d0657-2a49-4a4b-855b-4379bd0bacc3.png)

</details>

**Here is something problematic**
There seems to be a python 3.8 install, but we are already in an python:3.9.7-alpine3.13 image. 
<details>
  <summary>Expand screenshots of disk usage - python3.8 and next</summary>

![image](https://user-images.githubusercontent.com/27212526/151766841-37734886-e566-400e-a907-b1f27628275c.png)
![image](https://user-images.githubusercontent.com/27212526/151768453-425ca482-88d0-49d4-af72-8e13c25d0a7b.png)

`__pycache__` can be safely deleted since it is where the .pyc files (compiled versions) for the interpreter are stored (they are made when running a .py file).
![image](https://user-images.githubusercontent.com/27212526/151767178-8ec78beb-0574-4a87-a4d4-0b541683d19b.png)
![image](https://user-images.githubusercontent.com/27212526/151767402-555ce9f6-4cf5-4a59-8676-b7372afe0a15.png)


-----

![image](https://user-images.githubusercontent.com/27212526/151768007-1cd5c84d-1162-4011-865d-56c42734d4ff.png)
![image](https://user-images.githubusercontent.com/27212526/151768037-9fa855da-8cb4-4e5f-a8fa-5c24abc8e2a5.png)
![image](https://user-images.githubusercontent.com/27212526/151768281-6472f298-329b-44f7-adb8-e9c228b26a12.png)
![image](https://user-images.githubusercontent.com/27212526/151768301-f907a47d-84bd-4de9-bb38-e5b0c127dea8.png)


-----

![image](https://user-images.githubusercontent.com/27212526/151768490-7731b102-519e-494c-899a-43639c5aaefc.png)
![image](https://user-images.githubusercontent.com/27212526/151768516-ec555d90-b1e7-4c86-984f-095e334822d7.png)
![image](https://user-images.githubusercontent.com/27212526/151768536-03d74cca-80d2-4d3b-9b06-9f882ee37f04.png)
![image](https://user-images.githubusercontent.com/27212526/151768549-f5eeaf59-e20a-4ca1-9204-5f35b3e3464c.png)
![image](https://user-images.githubusercontent.com/27212526/151768577-94e879c6-cf03-4553-a5fa-dcacbeb7af90.png)
![image](https://user-images.githubusercontent.com/27212526/151768816-e255429c-8012-4fdc-baf4-1b0ae6c4bf91.png)
![image](https://user-images.githubusercontent.com/27212526/151768885-32e4b2d1-786c-4252-bd73-229bf625112d.png)
![image](https://user-images.githubusercontent.com/27212526/151768914-618a49b3-baf6-4569-91f6-612474f6a6a0.png)
![image](https://user-images.githubusercontent.com/27212526/151768923-c5e5660f-4289-49f4-ab42-38a4b62f8f67.png)


-----

![image](https://user-images.githubusercontent.com/27212526/151769070-f38dd9ff-f50d-4dfc-b303-399405c8a122.png)
![image](https://user-images.githubusercontent.com/27212526/151769091-55553ec0-55d0-435d-b1b9-27ae0044a201.png)


-----

![image](https://user-images.githubusercontent.com/27212526/151769120-1ab58093-80e2-4120-a5ef-b7ee5a9ad967.png)
![image](https://user-images.githubusercontent.com/27212526/151769142-cefa53e3-ac6a-432c-9669-f8ddcbc6a410.png)

-----

Here, are we sure we need FSharp? We could also take a look at the dotnet images to make sure we really need the full SDK https://hub.docker.com/_/microsoft-dotnet or we can make a published version of the tools we use, and thus only need a runtime base to run a .dll https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/docker/building-net-docker-images?view=aspnetcore-6.0
![image](https://user-images.githubusercontent.com/27212526/151769193-c0ed8cbb-5ad9-49e3-9bf7-d8014d08415c.png)



-----
What is this `false` folder? It seems like a boolean value was used as a string and made a folder instead of ignoring it.
![image](https://user-images.githubusercontent.com/27212526/151770745-9948bde4-ec92-4079-b3a1-cbb7693294c1.png)
![image](https://user-images.githubusercontent.com/27212526/151770905-eafef187-8def-4959-8284-3eafe3abeab2.png)
![image](https://user-images.githubusercontent.com/27212526/151770939-5ae3fe04-8fa3-4625-8793-9eadbf83c8bd.png)


-----

Go cache to clear
![image](https://user-images.githubusercontent.com/27212526/151771032-cc4e40bb-d049-4a18-9684-51247626c4ec.png)
![image](https://user-images.githubusercontent.com/27212526/151771109-512f8599-4c3e-4878-af22-6f6f6724fa6f.png)
![image](https://user-images.githubusercontent.com/27212526/151771079-642d877b-c90b-4bac-abd9-de27dc643a4a.png)


-----

`/tmp` might be to clear at each layer:
![image](https://user-images.githubusercontent.com/27212526/151771245-badd5754-7992-4e7f-b271-0c4a040dd37c.png)



------

![image](https://user-images.githubusercontent.com/27212526/151771416-d1555269-4d81-4927-afc8-6ea88b691bab.png)
![image](https://user-images.githubusercontent.com/27212526/151771536-a4c9b2b7-7f53-44e2-9432-2e66a452e85e.png)
![image](https://user-images.githubusercontent.com/27212526/151771563-53094d96-8805-46b7-8d6c-b6bc5697f124.png)

![image](https://user-images.githubusercontent.com/27212526/151771586-7cdfc62c-c290-4deb-8c99-cab8dfa17422.png)
![image](https://user-images.githubusercontent.com/27212526/151771619-16006599-35cb-4079-97bf-897335522d8b.png)
![image](https://user-images.githubusercontent.com/27212526/151771636-88741ec9-d46a-42e1-9c2f-46f2e3fdccce.png)
![image](https://user-images.githubusercontent.com/27212526/151771661-33b1a903-349f-4bc7-be49-aa0f286c6e21.png)


![image](https://user-images.githubusercontent.com/27212526/151771748-cea4360a-7158-4770-a8bc-cab7da7d6051.png)
![image](https://user-images.githubusercontent.com/27212526/151771775-569bce32-3dfc-469a-aabf-27201b5ee25b.png)
![image](https://user-images.githubusercontent.com/27212526/151771798-97eed405-e4a5-41b1-b80a-b3202338acd5.png)

-------

`R`:
![image](https://user-images.githubusercontent.com/27212526/151771873-09dd7340-0340-46d3-b202-630138cd4117.png)
![image](https://user-images.githubusercontent.com/27212526/151771890-b93d155f-837a-48f8-9564-8cd90728b9b6.png)
![image](https://user-images.githubusercontent.com/27212526/151771904-1e8aaf4c-97ff-41be-b310-da40f8c53067.png)


</details>


<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. It is only a start with these three tools. When files are dowloaded, extracted, and copied at the final folder, the downloaded archive and the extracted archive are kept in the layer. Since the all flavor is 7.6 GB extracted, there is some optimisation to do.


## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
  - Not breaking

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
