### PR TITLE
Fix suggestion to use proper variable name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fixes
   - Manage to use local certificate with Gitlab comments reporter using GITLAB_SSL_CERTIFICATE_PATH ([#1239](https://github.com/megalinter/megalinter/issues/1239))
+  - Fix GITLAB_ACCESS_TOKEN_MEGALINTER suggestion when trying to push comments to gitlab merge request
 
 Note: Can be used with `megalinter/megalinter@beta` in your GitHub Action mega-linter.yml file, or with `megalinter/megalinter:beta` docker image
 

--- a/megalinter/reporters/GitlabCommentReporter.py
+++ b/megalinter/reporters/GitlabCommentReporter.py
@@ -166,7 +166,7 @@ class GitlabCommentReporter(Reporter):
     def display_auth_error(self, e):
         logging.error(
             "[Gitlab Comment Reporter] You may need to define a masked Gitlab CI/CD variable "
-            "MEGALINTER_ACCESS_TOKEN containing a personal token with scope 'api'\n"
+            "GITLAB_MEGALINTER_ACCESS_TOKEN containing a personal token with scope 'api'\n"
             "(if already defined, your token is probably invalid)\n"
             "If you are using local certificate, you also may need to define variables "
             "GITLAB_CUSTOM_CERTIFICATE or GITLAB_CERTIFICATE_PATH" + str(e)


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

The suggestion to use a token on gitlab to publish comments is not in sync with the actual variable.
This PR fixes the text to match the code.

## Proposed Changes

1. rename the variable in the comment.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
