### PR TITLE
Fix `no override and no default toolchain set` when lint rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Note: Can be used with `megalinter/megalinter@beta` in your GitHub Action mega-l
   - Allow to provide CI_ACTION_RUN_URL to build hlink for GitHub Comments reporter messages ([[#1341](https://github.com/megalinter/megalinter/issues/1341))
   - Display plugin URL in MegaLinter output logs ([[#1340](https://github.com/megalinter/megalinter/issues/1340))
   - Fix public glibc public key download
+  - Fix `no override and no default toolchain set` when lint rust with clippy via github-action ([#975](https://github.com/megalinter/megalinter/issues/975))
 
 - Doc
   - Add instructions to upload artifacts when using MegaLinter with Jenkins

--- a/megalinter/descriptors/rust.megalinter-descriptor.yml
+++ b/megalinter/descriptors/rust.megalinter-descriptor.yml
@@ -10,7 +10,8 @@ install:
     - ENV PATH="/root/.cargo/bin:${PATH}"
 linters:
   # CLIPPY
-  - linter_name: clippy
+  - class: ClippyLinter
+    linter_name: clippy
     linter_url: https://github.com/rust-lang/rust-clippy
     linter_rules_url: https://rust-lang.github.io/rust-clippy/stable/index.html
     linter_rules_configuration_url: https://github.com/rust-lang/rust-clippy#configuration

--- a/megalinter/linters/ClippyLinter.py
+++ b/megalinter/linters/ClippyLinter.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""
+Use Clippy to lint rust files
+"""
+import logging
+import os
+
+import megalinter
+
+
+class ClippyLinter(megalinter.Linter):
+
+    # To execute before linting files
+    def before_lint_files(self):
+        # Build pre-command
+        if not os.path.isfile(os.path.expandvars("${HOME}/.rustup/settings.toml")):
+            rustup_init_command = "rustup default stable"
+            if self.pre_commands is None:
+                self.pre_commands = []
+            # Add to pre-commands
+            logging.debug("clippy before_lint_files: " + rustup_init_command)
+            self.pre_commands.append({
+                "command": rustup_init_command,
+                "cwd": self.workspace
+            })


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #975

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. run `rustup default stable` if the config file `$HOME/.rustup/settings.toml` is not found (eg when $HOME is redefined like in github-action)

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
