### PR TITLE
Define pre-commit hooks.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,66 @@
+- id: megalinter
+  name: Run MegaLinter on files modified relative to DEFAULT_BRANCH
+  entry: npx --
+  language: system
+  pass_filenames: false
+  args:
+    - mega-linter-runner
+    - --fix
+    - --env
+    - "'APPLY_FIXES=all'"
+    - --env
+    - "'FAIL_IF_UPDATED_SOURCES=true'"
+    - --env
+    - "'LOG_LEVEL=warning'"
+    - --env
+    - "'VALIDATE_ALL_CODEBASE=false'"
+    - --env
+    - "'DISABLE_LINTERS=COPYPASTE_JSCPD'"
+  stages:
+    - commit
+  description: >
+    See https://megalinter.github.io/latest/mega-linter-runner/#usage and
+    https://megalinter.github.io/latest/configuration/ if you wish to override
+    the default arguments. mega-linter-runner is specified as an argument so
+    that you may override the version (e.g., mega-linter-runner@vx.y.z). Depends
+    on npx, which ships with npm 7+, and Docker. Unlike most pre-commit hooks,
+    MegaLinter itself computes the files to run on. Runs very slowly when the
+    pertinent Docker image isn't already cached (c.f.,
+    https://github.com/marketplace/actions/docker-cache/). If you encounter
+    permission errors, try running Docker in rootless mode (c.f.,
+    https://github.com/marketplace/actions/rootless-docker/). Linter results are
+    logged to the report directory, so you should make sure to list it in your
+    .gitignore and wipe it between runs. Skip jscpd since duplicate detection
+    fundamentally requires scanning the entire repository and hence can't be
+    performed incrementally.
+
+- id: megalinter-all
+  name: Run MegaLinter on all files
+  entry: npx --
+  language: system
+  pass_filenames: false
+  args:
+    - mega-linter-runner
+    - --fix
+    - --env
+    - "'APPLY_FIXES=all'"
+    - --env
+    - "'FAIL_IF_UPDATED_SOURCES=true'"
+    - --env
+    - "'LOG_LEVEL=warning'"
+    - --env
+    - "'VALIDATE_ALL_CODEBASE=true'"
+  stages:
+    - push
+  description: >
+    See https://megalinter.github.io/latest/mega-linter-runner/#usage and
+    https://megalinter.github.io/latest/configuration/ if you wish to override
+    the default arguments. mega-linter-runner is specified as an argument so
+    that you may override the version (e.g., mega-linter-runner@vx.y.z). Depends
+    on npx, which ships with npm 7+, and Docker. Runs very slowly when the
+    pertinent Docker image isn't already cached (c.f.,
+    https://github.com/marketplace/actions/docker-cache/). If you encounter
+    permission errors, try running Docker in rootless mode (c.f.,
+    https://github.com/marketplace/actions/rootless-docker/). Linter results are
+    logged to the report directory, so you should make sure to list it in your
+    .gitignore and wipe it between runs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 Note: Can be used with `megalinter/megalinter@beta` in your GitHub Action mega-linter.yml file, or with `megalinter/megalinter:beta` docker image
 
 - Add gherkin-lint in dotnet flavor ([#1435](https://github.com/megalinter/megalinter/issues/1435))
+- Define pre-commit hooks ([#569](https://github.com/megalinter/megalinter/issues/569)).
 
 - Linter versions upgrades
   - [luacheck](https://luacheck.readthedocs.io) from 0.26.0 to **0.26.1** on 2022-04-24

--- a/mega-linter-runner/README.md
+++ b/mega-linter-runner/README.md
@@ -103,7 +103,7 @@ mega-linter-runner -r beta -e 'ENABLE=MARKDOWN,YAML' -e 'SHOW_ELAPSED_TIME=true'
 
 ## Configuration
 
-You can define generate a ready to use [.mega-linter.yml configuration file](https://megalinter.github.io/configuration/) by running `npx mega-linter-runner --install` at the root of your repository
+You can generate a ready-to-use [.mega-linter.yml configuration file](https://megalinter.github.io/configuration/) by running `npx mega-linter-runner --install` at the root of your repository
 
 ![Runner Install](https://github.com/megalinter/megalinter/blob/main/docs/assets/images/mega-linter-runner-generator.gif?raw=true)
 

--- a/mega-linter-runner/README.md
+++ b/mega-linter-runner/README.md
@@ -65,6 +65,23 @@ Example:
 npx mega-linter-runner -r beta -e 'ENABLE=MARKDOWN,YAML' -e 'SHOW_ELAPSED_TIME=true'
 ```
 
+### Pre-commit hook
+
+You can run mega-linter-runner as a [pre-commit](https://pre-commit.com/) hook
+
+Sample `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/megalinter/megalinter
+    rev: v5.12.0 # Git tag specifying the hook, not mega-linter-runner, version
+    hooks:
+      - id: megalinter # Faster, less thorough, runs pre-commit by default
+      - id: megalinter-all # Slower, more thorough, runs pre-push by default
+```
+
+See [`.pre-commit-hooks.yaml`](../.pre-commit-hooks.yaml) for more details.
+
 ## Usage
 
 ```shell


### PR DESCRIPTION
Fixes #569.

## Proposed Changes

1. The pre-commit framework allows users to run MegaLinter locally as a Git pre-commit hook. While it does have built-in support for Node.js hooks, it doesn't support monorepos, because the `package.json` must be in the root directory. While it does have built-in support for Docker hooks, the user experience of overriding arguments to `mega-linter-runner` is nicer than that for the Docker image. Hence, hand-roll system hooks instead, and leverage `npx` to execute (and, if necessary, download) `mega-linter-runner`.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
